### PR TITLE
fix(calculator): correctly handle percentage calculations in operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@testing-library/react": "^16.2.0",
         "cra-template-typescript": "1.2.0",
+        "mathjs": "^14.2.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-scripts": "^5.0.1"
@@ -5742,6 +5743,19 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "license": "MIT"
     },
+    "node_modules/complex.js": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.2.tgz",
+      "integrity": "sha512-qtx7HRhPGSCBtGiST4/WGHuW+zeaND/6Ld+db6PbrulIB1i2Ev/2UPiqcmpQNPSyfBKraC0EOvOKCB5dGZKt3g==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -7058,6 +7072,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -9869,6 +9889,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "license": "MIT"
+    },
     "node_modules/jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
@@ -11214,6 +11240,42 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mathjs": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-14.2.1.tgz",
+      "integrity": "sha512-vARWETUx75+kR2K9qBV20n6NYtGXCuQKX8Zo4+AhJI5LX+ukSM1NYebv+wLnJG8KMvEe9H01sJUyC5bMciA4Tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mathjs/node_modules/fraction.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.2.1.tgz",
+      "integrity": "sha512-Ah6t/7YCYjrPUFUFsOsRLMXAdnYM+aQwmojD2Ayb/Ezr82SwES0vuyQ8qZ3QO8n9j7W14VJuVZZet8U3bhSdQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/mdn-data": {
@@ -14573,6 +14635,12 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "license": "MIT"
+    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -15985,6 +16053,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -16238,6 +16312,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-function": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.1.tgz",
+      "integrity": "sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/typedarray-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@testing-library/react": "^16.2.0",
     "cra-template-typescript": "1.2.0",
+    "mathjs": "^14.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-scripts": "^5.0.1"

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Display from "./Display.tsx";
 import Button from "./Button.tsx";
+import * as math from "mathjs";
 
 // Main Calculator component containing the logic
 const Calculator: React.FC = () => {
@@ -14,8 +15,9 @@ const Calculator: React.FC = () => {
     if (value === "=") {
       // If the "=" button is clicked, evaluate the operation
       try {
-        setResult(eval(operation).toString()); // Evaluate the operation and set the result
-        setOperation(""); // Clear the operation
+        const expression = operation.replace(/(\d+(\.\d+)?)%/g, "($1/100)"); // Replace % with /100 for math.js evaluation
+        const result = math.evaluate(expression); // Use math.js to evaluate the operation
+        setResult(result.toString()); // Set the result
       } catch (error) {
         setResult("Error"); // Display an error if the operation is invalid
       }
@@ -26,17 +28,6 @@ const Calculator: React.FC = () => {
     } else if (value === "←") {
       // If the "←" button is clicked, remove the last character from the operation
       setOperation(operation.slice(0, -1));
-    } else if (value === "%") {
-      // If the "%" button is clicked, calculate the percentage of the last number
-      try {
-        const lastNumber = operation.match(/\d+\.?\d*$/); // Find the last number in the operation
-        if (lastNumber) {
-          const percent = eval(lastNumber[0]) / 100; // Calculate the percentage
-          setOperation(operation + percent.toString()); // Append the percentage to the operation
-        }
-      } catch (error) {
-        setResult("Error"); // Display an error if the operation is invalid
-      }
     } else {
       // For all other buttons, append the value to the operation
       setOperation(operation + value);


### PR DESCRIPTION
- Replace `%` with `/100` using regex to allow math.js to evaluate percentages.
- Update the logic to preserve the original operation string while evaluating percentages.
- Add support for complex expressions like `100 * 6% - 563 * 7 + 2589  / 9%`.
- Fixes the issue where percentages were not being calculated correctly.

This change ensures that percentages are handled correctly in all operations, improving the accuracy and functionality of the calculator.